### PR TITLE
f-version-by-teamcity

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: teamcity
-version: 0.1.0
+version: version-by-teamcity


### PR DESCRIPTION
With this PR, the version is injected by teamcity into the `Chart.yaml` file, based on the tag (for example, `1.0.0`, and picked up by artifactory automatically and indexed. 